### PR TITLE
Fill buffer to 4 bytes if needed inside convertBinaryToInteger function

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,11 @@ Header.prototype.parseFieldSubRecord = function(buffer) {
 };
 
 Header.prototype.convertBinaryToInteger = function(buffer) {
-    return buffer.readInt32LE(0, true);
+    const fillerBytesCount = 4 - buffer.length;
+    const fillerBytes = Buffer.alloc(fillerBytesCount, 0);
+    const filledBuffer = Buffer.concat([buffer, fillerBytes]);
+    
+    return filledBuffer.readInt32LE(0);
 };
 
 


### PR DESCRIPTION
Since Node 10 `noAssert` parameter of the Buffer read/write methods was removed.

In order to make the parser work with newer Node versions, fill the received buffer inside `convertBinaryToInteger`, if needed .